### PR TITLE
Use Eigen::Map for activation layer outputs

### DIFF
--- a/RTNeural/activation/activation_eigen.h
+++ b/RTNeural/activation/activation_eigen.h
@@ -49,7 +49,7 @@ public:
     static constexpr auto out_size = size;
 
     TanhActivationT()
-            : outs(outs_internal)
+        : outs(outs_internal)
     {
         outs = v_type::Zero();
     }
@@ -116,7 +116,7 @@ public:
     static constexpr auto out_size = size;
 
     FastTanhT()
-            : outs(outs_internal)
+        : outs(outs_internal)
     {
         outs = v_type::Zero();
     }
@@ -254,7 +254,7 @@ public:
     static constexpr auto out_size = size;
 
     SigmoidActivationT()
-            : outs(outs_internal)
+        : outs(outs_internal)
     {
         outs = v_type::Zero();
     }


### PR DESCRIPTION
Discovered when investigating #55. `RTNeural::ModelT` expects the layer output to be an `Eigen::Map` so it can replace the memory with a placement new for the final layer. Previously, the Eigen activation layer implementations were using regular Eigen matrices, so the placement new would not correctly remap the memory if an activation function is the final layer in a network.