### PR TITLE
RFC: Allow use of abstract ModelT

### DIFF
--- a/RTNeural/ModelT.h
+++ b/RTNeural/ModelT.h
@@ -202,6 +202,22 @@ namespace modelt_detail
 } // namespace modelt_detail
 #endif // DOXYGEN
 
+#if RTNEURAL_ABSTRACT_MODELT
+/**
+ *  An abstract class for ModelT, allowing to dynamically create static model types.
+ *
+ *  It provides the needed methods from ModelT for an audio plugin implementation.
+ */
+class AbstractModelT
+{
+public:
+    virtual ~AbstractModel() {}
+    virtual void parseJson(const nlohmann::json& parent, const bool debug = false, std::initializer_list<std::string> custom_layers = {}) = 0;
+    virtual void reset() = 0;
+    virtual float forwardf(const float* input) = 0;
+};
+#endif
+
 /**
  *  A static sequential neural network model.
  *
@@ -216,6 +232,9 @@ namespace modelt_detail
  */
 template <typename T, int in_size, int out_size, typename... Layers>
 class ModelT
+#if RTNEURAL_ABSTRACT_MODELT
+    : public AbstractModelT
+#endif
 {
 public:
     ModelT()
@@ -304,6 +323,14 @@ public:
 #endif
         return outs[0];
     }
+
+#if RTNEURAL_ABSTRACT_MODELT
+    /** Helper forward call for abstract models. */
+    float forwardf(const float* input)
+    {
+        return forward(input);
+    }
+#endif
 
     /** Returns a pointer to the output of the final layer in the network. */
     inline const T* getOutputs() const noexcept


### PR DESCRIPTION
Me and @KaisKermani have been testing RTNeural in the context of https://github.com/AidaDSP/aidadsp-lv2 plugin, trying to find a way to make it load json files at runtime without losing performance compared to the statically constructed model types.
One approach that proved to work is to make an abstract Model class and use that as the pointer type to which the plugin calls into, which allows stuff like this:

```
// in plugin header
AbstractModelT* dynamicmodel;

// in runtime, after loading a json file to figure out what architecture it needs
dynamicmodel = new RTNeural::ModelT<float, 1, 1, RTNeural::LSTMLayerT<float, 1, 40>, RTNeural::DenseT<float, 40, 1>>;
```

Compared to the more dynamic handling of the json namespace methods, this approach gives a performance equal to creating the model with all parameters set in the code (kinda expected, as it does pass all template params in a static way).
Our idea is to have a verbose/extended json parser that then creates all known architectures possible in this "static" way, thus not losing performance. 

This is a first test patch, meant for general feedback.
A proper patch would at least need the abstract class to have a template for float/double/etc type.
And I am not sure what to call that new `forwardf` call, we just need it to not be "forward" as to avoid recursion and name clashes.

What do you think?