### PR TITLE
Fix log + Use const ints to define model shapes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,4 @@ demonstrate usage of the RTNeural library:
 - `rtneural_static_model`: Demonstrates how to use the RTNeural compile-time API to load and run a static model.
 - `rtneural_dynamic_model`: Demonstrates how to use the RTNeural run-time API to load and run a model from a file.
 - `custom_layer_model`: Demonstrates how to extend RTNeural's compile-time API with custom layers.
+- `torch`: Demonstrates how to use the RTNeural compile-time API to import pytorch models. The exporting from python pytorch of the models used in those examples can be found in [RTNeural/python](../python/). They have a `_torch` postfix.

--- a/examples/torch/torch_gru/torch_gru.cpp
+++ b/examples/torch/torch_gru/torch_gru.cpp
@@ -34,9 +34,9 @@ std::string getOutputFile(fs::path path)
     return path.string();
 }
 
-const int gru_input_size = 1;
-const int gru_hidden_size = 8;
-const int n_output_neurons = 1;
+constexpr int gru_input_size = 1;
+constexpr int gru_hidden_size = 8;
+constexpr int n_output_neurons = 1;
 
 using ModelType = RTNeural::ModelT<float, gru_input_size, n_output_neurons,
     RTNeural::GRULayerT<float, gru_input_size, gru_hidden_size>,

--- a/examples/torch/torch_gru/torch_gru.cpp
+++ b/examples/torch/torch_gru/torch_gru.cpp
@@ -34,7 +34,14 @@ std::string getOutputFile(fs::path path)
     return path.string();
 }
 
-using ModelType = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 8>, RTNeural::DenseT<float, 8, 1>>;
+const int gru_input_size = 1;
+const int gru_hidden_size = 8;
+const int n_output_neurons = 1;
+
+using ModelType = RTNeural::ModelT<float, gru_input_size, n_output_neurons,
+    RTNeural::GRULayerT<float, gru_input_size, gru_hidden_size>,
+    RTNeural::DenseT<float, gru_hidden_size, n_output_neurons>>;
+
 
 void loadModel(std::ifstream& jsonStream, ModelType& model)
 {
@@ -50,7 +57,7 @@ void loadModel(std::ifstream& jsonStream, ModelType& model)
 
 int main([[maybe_unused]] int argc, char* argv[])
 {
-    std::cout << "Running \"torch conv1d\" example..." << std::endl;
+    std::cout << "Running \"torch gru\" example..." << std::endl;
 
     auto executablePath = fs::weakly_canonical(fs::path(argv[0]));
     auto modelFilePath = getModelFile(executablePath);


### PR DESCRIPTION
Thank you for development of this framework! I've just started using it, but it already seems a  very good choice for my needs

I made some tiny changes to torch_gru.cpp example:

1. Fix console log of torch_gru.cpp example:
```
"Running \"torch conv1d\" example..."
```
->
```
"Running \"torch gru\" example..."
```

2. I think that it would be easier for an inexperienced person to understand ModelType definition if the shapes were named const integers rather than literals. So I made this change:

``` c++
using ModelType = RTNeural::ModelT<float, 1, 1, RTNeural::GRULayerT<float, 1, 8>, RTNeural::DenseT<float, 8, 1>>;
```

->

``` c++
const int gru_input_size = 1;
const int gru_hidden_size = 8;
const int n_output_neurons = 1;

using ModelType = RTNeural::ModelT<float,
    gru_input_size, n_output_neurons,
    RTNeural::GRULayerT<float, gru_input_size, gru_hidden_size>,
    RTNeural::DenseT<float, gru_hidden_size, n_output_neurons>>;
```