### PR TITLE
Use tanh to speed up sigmoid calculation

### DIFF
--- a/RTNeural/maths/maths_eigen.h
+++ b/RTNeural/maths/maths_eigen.h
@@ -16,7 +16,8 @@ struct DefaultMathsProvider
     static auto sigmoid(const Matrix& x)
     {
         using T = typename Matrix::Scalar;
-        return (T)1 / (((T)-1 * x.array()).array().exp() + (T)1);
+
+        return ((x.array() / (T)2).array().tanh() + (T)1) / (T)2;
     }
 
     template <typename Matrix>


### PR DESCRIPTION
For LSTM networks, the sigmoid activation function is very much in the performance hot path.

This PR defines the sigmoid calculation based on tanh() instead of exp(). It results in a significant performance improvement - I *think* because you are using a faster tanh approximation in your Eigen code.

It is hard to follow the twists through the Eigen code to the root tanh function, but I think this is what gets used?

https://github.com/jatinchowdhury18/RTNeural/blob/32b8664ca7c2f2ff8e5cbea924c0223f1af85bc0/modules/Eigen/Eigen/src/Core/MathFunctionsImpl.h#L166

It will obviously vary based on platform and network architecture, but in my testing I was seeing around 50% of CPU going to the sigmoid calculation. This change cuts that roughly in half, so the overall performance improvement is about 25% (or about 1.3x faster).