### PR TITLE
Add MathsProvider to template for dynamic model loading

### DIFF
--- a/RTNeural/model_loader.h
+++ b/RTNeural/model_loader.h
@@ -385,10 +385,10 @@ namespace json_parser
     }
 
     /** Creates a LSTMLayer from a json representation of the layer weights. */
-    template <typename T>
-    std::unique_ptr<LSTMLayer<T>> createLSTM(int in_size, int out_size, const nlohmann::json& weights)
+    template <typename T, typename MathsProvider = DefaultMathsProvider >
+    std::unique_ptr<LSTMLayer<T, MathsProvider>> createLSTM(int in_size, int out_size, const nlohmann::json& weights)
     {
-        auto lstm = std::make_unique<LSTMLayer<T>>(in_size, out_size);
+        auto lstm = std::make_unique<LSTMLayer<T, MathsProvider>>(in_size, out_size);
         loadLSTM<T>(*lstm.get(), weights);
         return std::move(lstm);
     }
@@ -602,7 +602,7 @@ namespace json_parser
     }
 
     /** Creates a neural network model from a json stream. */
-    template <typename T>
+    template <typename T, typename MathsProvider = DefaultMathsProvider>
     std::unique_ptr<Model<T>> parseJson(const nlohmann::json& parent, const bool debug = false)
     {
         auto shape = parent.at("in_shape");
@@ -688,7 +688,7 @@ namespace json_parser
             }
             else if(type == "lstm")
             {
-                auto lstm = createLSTM<T>(model->getNextInSize(), layerDims, weights);
+                auto lstm = createLSTM<T, MathsProvider>(model->getNextInSize(), layerDims, weights);
                 model->addLayer(lstm.release());
             }
             else if(type == "prelu")

--- a/RTNeural/model_loader.h
+++ b/RTNeural/model_loader.h
@@ -318,10 +318,10 @@ namespace json_parser
     }
 
     /** Creates a GRULayer from a json representation of the layer weights. */
-    template <typename T>
-    std::unique_ptr<GRULayer<T>> createGRU(int in_size, int out_size, const nlohmann::json& weights)
+    template <typename T, typename MathsProvider = DefaultMathsProvider>
+    std::unique_ptr<GRULayer<T, MathsProvider>> createGRU(int in_size, int out_size, const nlohmann::json& weights)
     {
-        auto gru = std::make_unique<GRULayer<T>>(in_size, out_size);
+        auto gru = std::make_unique<GRULayer<T, MathsProvider>>(in_size, out_size);
         loadGRU<T>(*gru.get(), weights);
         return std::move(gru);
     }
@@ -560,24 +560,24 @@ namespace json_parser
     }
 
     /** Creates an activation layer of a given type. */
-    template <typename T>
+    template <typename T, typename MathsProvider = DefaultMathsProvider>
     std::unique_ptr<Activation<T>>
     createActivation(const std::string& activationType, int dims)
     {
         if(activationType == "tanh")
-            return std::make_unique<TanhActivation<T>>(dims);
+            return std::make_unique<TanhActivation<T, MathsProvider>>(dims);
 
         if(activationType == "relu")
             return std::make_unique<ReLuActivation<T>>(dims);
 
         if(activationType == "sigmoid")
-            return std::make_unique<SigmoidActivation<T>>(dims);
+            return std::make_unique<SigmoidActivation<T, MathsProvider>>(dims);
 
         if(activationType == "softmax")
-            return std::make_unique<SoftmaxActivation<T>>(dims);
+            return std::make_unique<SoftmaxActivation<T, MathsProvider>>(dims);
 
         if(activationType == "elu")
-            return std::make_unique<ELuActivation<T>>(dims);
+            return std::make_unique<ELuActivation<T, MathsProvider>>(dims);
 
         return {};
     }
@@ -639,7 +639,7 @@ namespace json_parser
                     if(!activationType.empty())
                     {
                         debug_print("  activation: " + activationType, debug);
-                        auto activation = createActivation<T>(activationType, layerDims);
+                        auto activation = createActivation<T, MathsProvider>(activationType, layerDims);
                         _model->addLayer(activation.release());
                     }
                 }
@@ -683,7 +683,7 @@ namespace json_parser
             }
             else if(type == "gru")
             {
-                auto gru = createGRU<T>(model->getNextInSize(), layerDims, weights);
+                auto gru = createGRU<T, MathsProvider>(model->getNextInSize(), layerDims, weights);
                 model->addLayer(gru.release());
             }
             else if(type == "lstm")


### PR DESCRIPTION
This PR adds the MathsProvider template parameter for the dynamic model json parser. I wired it up so that it gets used for LSTM layer creation - other layers may also need it.