### PR TITLE
Optimize small XSIMD Conv1D kernels

### DIFF
--- a/RTNeural/conv1d/conv1d_xsimd.h
+++ b/RTNeural/conv1d/conv1d_xsimd.h
@@ -275,7 +275,7 @@ public:
         // set state pointers to particular columns of the buffer
         setStatePointers();
 
-        if(use_output_parallel)
+        RTNEURAL_IF_CONSTEXPR(use_output_parallel)
         {
             for(int i = 0; i < v_out_size; ++i)
                 outs[i] = bias[i];
@@ -338,7 +338,7 @@ public:
         // set state pointers to particular columns of the buffer
         setStatePointers();
 
-        if(use_output_parallel)
+        RTNEURAL_IF_CONSTEXPR(use_output_parallel)
         {
             for(int i = 0; i < v_out_size; ++i)
                 outs[i] = bias[i];
@@ -392,7 +392,7 @@ public:
     RTNEURAL_REALTIME inline typename std::enable_if<DR == 1 && KS == 1 && G == 1, void>::type
     forward(const v_type (&ins)[v_in_size]) noexcept
     {
-        if(use_output_parallel)
+        RTNEURAL_IF_CONSTEXPR(use_output_parallel)
         {
             for(int i = 0; i < v_out_size; ++i)
                 outs[i] = bias[i];
@@ -465,9 +465,15 @@ private:
     template <int DS = dynamic_state>
     typename std::enable_if<!DS, void>::type resize_state() { }
 
+    // Output-parallel computation is beneficial when at least one matrix
+    // dimension fits in a single SIMD register. Larger matrices retain the
+    // input-parallel kernel to avoid extra scalar broadcasts.
+    static constexpr bool use_output_parallel = groups == 1 && (v_in_size == 1 || v_out_size == 1);
+
     using state_col_type = std::array<v_type, v_in_size>;
     using state_type = typename std::conditional<dynamic_state, std::vector<state_col_type, xsimd::aligned_allocator<state_col_type>>, std::array<state_col_type, state_size>>::type;
     using weights_type = std::array<std::array<v_type, v_filters_per_group>, kernel_size>;
+    using weights_storage_type = std::array<weights_type, use_output_parallel ? 0 : out_size>;
 
     state_type state {};
     weights_type state_cols {};
@@ -475,13 +481,8 @@ private:
     int state_ptr = 0;
     std::array<int, kernel_size> state_ptrs {};
 
-    weights_type weights[out_size] {};
+    weights_storage_type weights {};
     v_type bias[v_out_size] {};
-
-    // Output-parallel computation is beneficial when at least one matrix
-    // dimension fits in a single SIMD register. Larger matrices retain the
-    // input-parallel kernel to avoid extra scalar broadcasts.
-    static constexpr bool use_output_parallel = groups == 1 && (v_in_size == 1 || v_out_size == 1);
 
     // Transposed weights for output-parallel computation.
     // weights_ot[kernel_pos][in_channel][out_simd_group]

--- a/RTNeural/conv1d/conv1d_xsimd.h
+++ b/RTNeural/conv1d/conv1d_xsimd.h
@@ -275,34 +275,53 @@ public:
         // set state pointers to particular columns of the buffer
         setStatePointers();
 
-        // copy selected columns to a helper variable
-        for(int k = 0; k < kernel_size; ++k)
+        if(use_output_parallel)
         {
-            const auto& col = state[state_ptrs[k]];
-            std::copy(col.begin(), col.end(), state_cols[k].begin());
-        }
+            for(int i = 0; i < v_out_size; ++i)
+                outs[i] = bias[i];
 
-        // perform multi-channel convolution
-        for(int i = 0; i < v_out_size; ++i)
-        {
-            alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
-            for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
+            for(int j = 0; j < kernel_size; ++j)
             {
-                assert(i * v_size + k < out_size);
-                const auto& subWeights = weights[i * v_size + k];
-                v_type accum {};
-                for(int j = 0; j < kernel_size; ++j)
+                const auto& col = state[state_ptrs[j]];
+                for(int m = 0; m < v_in_size; ++m)
                 {
-                    accum += std::inner_product(
-                        subWeights[j].begin(),
-                        subWeights[j].end(),
-                        state_cols[j].begin(),
-                        v_type {});
+                    alignas(RTNEURAL_DEFAULT_ALIGNMENT) T elements[v_size];
+                    col[m].store_aligned(elements);
+                    for(int lane = 0; lane < v_size && (m * v_size + lane) < in_size; ++lane)
+                    {
+                        const v_type bcast(elements[lane]);
+                        const int ic = m * v_size + lane;
+                        for(int i = 0; i < v_out_size; ++i)
+                            outs[i] += bcast * weights_ot[j][ic][i];
+                    }
                 }
-                out_sum[k] = xsimd::reduce_add(accum);
             }
+        }
+        else
+        {
+            for(int k = 0; k < kernel_size; ++k)
+                std::copy(state[state_ptrs[k]].begin(), state[state_ptrs[k]].end(), state_cols[k].begin());
 
-            outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+            for(int i = 0; i < v_out_size; ++i)
+            {
+                alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
+                for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
+                {
+                    const auto& subWeights = weights[i * v_size + k];
+                    v_type accum {};
+                    for(int j = 0; j < kernel_size; ++j)
+                    {
+                        accum += std::inner_product(
+                            subWeights[j].begin(),
+                            subWeights[j].end(),
+                            state_cols[j].begin(),
+                            v_type {});
+                    }
+                    out_sum[k] = xsimd::reduce_add(accum);
+                }
+
+                outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+            }
         }
 
         state_ptr = (state_ptr == state_size - 1 ? 0 : state_ptr + 1); // iterate state pointer forwards
@@ -319,26 +338,50 @@ public:
         // set state pointers to particular columns of the buffer
         setStatePointers();
 
-        // perform multi-channel convolution
-        for(int i = 0; i < v_out_size; ++i)
+        if(use_output_parallel)
         {
-            alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
-            for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
-            {
-                const auto& subWeights = weights[i * v_size + k];
-                v_type accum {};
-                for(int j = 0; j < kernel_size; ++j)
-                {
-                    accum += std::inner_product(
-                        subWeights[j].begin(),
-                        subWeights[j].end(),
-                        state[(state_ptr + state_size - j) % state_size].begin(),
-                        v_type {});
-                }
-                out_sum[k] = xsimd::reduce_add(accum);
-            }
+            for(int i = 0; i < v_out_size; ++i)
+                outs[i] = bias[i];
 
-            outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+            for(int j = 0; j < kernel_size; ++j)
+            {
+                const auto& col = state[(state_ptr + state_size - j) % state_size];
+                for(int m = 0; m < v_in_size; ++m)
+                {
+                    alignas(RTNEURAL_DEFAULT_ALIGNMENT) T elements[v_size];
+                    col[m].store_aligned(elements);
+                    for(int lane = 0; lane < v_size && (m * v_size + lane) < in_size; ++lane)
+                    {
+                        const v_type bcast(elements[lane]);
+                        const int ic = m * v_size + lane;
+                        for(int i = 0; i < v_out_size; ++i)
+                            outs[i] += bcast * weights_ot[j][ic][i];
+                    }
+                }
+            }
+        }
+        else
+        {
+            for(int i = 0; i < v_out_size; ++i)
+            {
+                alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
+                for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
+                {
+                    const auto& subWeights = weights[i * v_size + k];
+                    v_type accum {};
+                    for(int j = 0; j < kernel_size; ++j)
+                    {
+                        accum += std::inner_product(
+                            subWeights[j].begin(),
+                            subWeights[j].end(),
+                            state[(state_ptr + state_size - j) % state_size].begin(),
+                            v_type {});
+                    }
+                    out_sum[k] = xsimd::reduce_add(accum);
+                }
+
+                outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+            }
         }
 
         state_ptr = (state_ptr == state_size - 1 ? 0 : state_ptr + 1); // iterate state pointer forwards
@@ -349,20 +392,41 @@ public:
     RTNEURAL_REALTIME inline typename std::enable_if<DR == 1 && KS == 1 && G == 1, void>::type
     forward(const v_type (&ins)[v_in_size]) noexcept
     {
-        for(int i = 0; i < v_out_size; ++i)
+        if(use_output_parallel)
         {
-            alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
-            for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
+            for(int i = 0; i < v_out_size; ++i)
+                outs[i] = bias[i];
+
+            for(int m = 0; m < v_in_size; ++m)
             {
-                const auto& subWeights = weights[i * v_size + k][0];
-
-                v_type accum {};
-                for(int j = 0; j < v_in_size; ++j)
-                    accum += subWeights[j] * ins[j];
-                out_sum[k] = xsimd::reduce_add(accum);
+                alignas(RTNEURAL_DEFAULT_ALIGNMENT) T elements[v_size];
+                ins[m].store_aligned(elements);
+                for(int lane = 0; lane < v_size && (m * v_size + lane) < in_size; ++lane)
+                {
+                    const v_type bcast(elements[lane]);
+                    const int ic = m * v_size + lane;
+                    for(int i = 0; i < v_out_size; ++i)
+                        outs[i] += bcast * weights_ot[0][ic][i];
+                }
             }
+        }
+        else
+        {
+            for(int i = 0; i < v_out_size; ++i)
+            {
+                alignas(RTNEURAL_DEFAULT_ALIGNMENT) T out_sum[v_size] {};
+                for(int k = 0; k < v_size && (i * v_size + k) < out_size; ++k)
+                {
+                    const auto& subWeights = weights[i * v_size + k][0];
 
-            outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+                    v_type accum {};
+                    for(int j = 0; j < v_in_size; ++j)
+                        accum += subWeights[j] * ins[j];
+                    out_sum[k] = xsimd::reduce_add(accum);
+                }
+
+                outs[i] = xsimd::load_aligned(out_sum) + bias[i];
+            }
         }
     }
 
@@ -413,6 +477,17 @@ private:
 
     weights_type weights[out_size] {};
     v_type bias[v_out_size] {};
+
+    // Output-parallel computation is beneficial when at least one matrix
+    // dimension fits in a single SIMD register. Larger matrices retain the
+    // input-parallel kernel to avoid extra scalar broadcasts.
+    static constexpr bool use_output_parallel = groups == 1 && (v_in_size == 1 || v_out_size == 1);
+
+    // Transposed weights for output-parallel computation.
+    // weights_ot[kernel_pos][in_channel][out_simd_group]
+    // Each v_type spans v_size output channels.
+    using weights_ot_col_type = std::array<v_type, use_output_parallel ? v_out_size : 0>;
+    weights_ot_col_type weights_ot[kernel_size][in_size] {};
 
     /** Sets pointers to state array columns. */
     inline void setStatePointers()

--- a/RTNeural/conv1d/conv1d_xsimd.tpp
+++ b/RTNeural/conv1d/conv1d_xsimd.tpp
@@ -76,16 +76,20 @@ void Conv1D<T>::setBias(const std::vector<T>& biasVals)
 template <typename T, int in_sizet, int out_sizet, int kernel_size, int dilation_rate, int groups, bool dynamic_state>
 Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic_state>::Conv1DT()
 {
-    for(int i = 0; i < out_size; ++i)
-        for(int j = 0; j < kernel_size; ++j)
-            for(int k = 0; k < v_filters_per_group; ++k)
-                weights[i][j][k] = v_type((T)0.0);
-
-    if(use_output_parallel)
+    RTNEURAL_IF_CONSTEXPR(use_output_parallel)
+    {
         for(int j = 0; j < kernel_size; ++j)
             for(int ic = 0; ic < in_size; ++ic)
                 for(int i = 0; i < v_out_size; ++i)
                     weights_ot[j][ic][i] = v_type((T)0.0);
+    }
+    else
+    {
+        for(int i = 0; i < out_size; ++i)
+            for(int j = 0; j < kernel_size; ++j)
+                for(int k = 0; k < v_filters_per_group; ++k)
+                    weights[i][j][k] = v_type((T)0.0);
+    }
 
     for(int i = 0; i < v_out_size; ++i)
         bias[i] = v_type((T)0.0);
@@ -116,24 +120,11 @@ void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic
 template <typename T, int in_sizet, int out_sizet, int kernel_size, int dilation_rate, int groups, bool dynamic_state>
 void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic_state>::setWeights(const std::vector<std::vector<std::vector<T>>>& ws)
 {
-    // Original per-output-channel weights (used by groups>1 overload)
-    for(int i = 0; i < out_size; ++i)
+    RTNEURAL_IF_CONSTEXPR(use_output_parallel)
     {
-        for(int k = 0; k < filters_per_group; ++k)
-        {
-            for(int j = 0; j < kernel_size; ++j)
-            {
-                auto& w = weights[i][j][k / v_size];
-                w = set_value(w, k % v_size, ws[i][k][j]);
-            }
-        }
-    }
-
-    // Transposed weights for output-parallel computation (groups==1 only):
-    // weights_ot[kernel_pos][in_channel][out_simd_group]
-    // Each v_type spans v_size consecutive output channels.
-    if(groups == 1 && use_output_parallel)
-    {
+        // Transposed weights for output-parallel computation:
+        // weights_ot[kernel_pos][in_channel][out_simd_group]
+        // Each v_type spans v_size consecutive output channels.
         for(int j = 0; j < kernel_size; ++j)
         {
             for(int ic = 0; ic < in_size; ++ic)
@@ -142,6 +133,21 @@ void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic
                 {
                     auto& wv = weights_ot[j][ic][oc / v_size];
                     wv = set_value(wv, oc % v_size, ws[oc][ic][j]);
+                }
+            }
+        }
+    }
+    else
+    {
+        // Per-output-channel weights for grouped and input-parallel convolution.
+        for(int i = 0; i < out_size; ++i)
+        {
+            for(int k = 0; k < filters_per_group; ++k)
+            {
+                for(int j = 0; j < kernel_size; ++j)
+                {
+                    auto& w = weights[i][j][k / v_size];
+                    w = set_value(w, k % v_size, ws[i][k][j]);
                 }
             }
         }

--- a/RTNeural/conv1d/conv1d_xsimd.tpp
+++ b/RTNeural/conv1d/conv1d_xsimd.tpp
@@ -81,6 +81,12 @@ Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic_stat
             for(int k = 0; k < v_filters_per_group; ++k)
                 weights[i][j][k] = v_type((T)0.0);
 
+    if(use_output_parallel)
+        for(int j = 0; j < kernel_size; ++j)
+            for(int ic = 0; ic < in_size; ++ic)
+                for(int i = 0; i < v_out_size; ++i)
+                    weights_ot[j][ic][i] = v_type((T)0.0);
+
     for(int i = 0; i < v_out_size; ++i)
         bias[i] = v_type((T)0.0);
 
@@ -110,6 +116,7 @@ void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic
 template <typename T, int in_sizet, int out_sizet, int kernel_size, int dilation_rate, int groups, bool dynamic_state>
 void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic_state>::setWeights(const std::vector<std::vector<std::vector<T>>>& ws)
 {
+    // Original per-output-channel weights (used by groups>1 overload)
     for(int i = 0; i < out_size; ++i)
     {
         for(int k = 0; k < filters_per_group; ++k)
@@ -118,6 +125,24 @@ void Conv1DT<T, in_sizet, out_sizet, kernel_size, dilation_rate, groups, dynamic
             {
                 auto& w = weights[i][j][k / v_size];
                 w = set_value(w, k % v_size, ws[i][k][j]);
+            }
+        }
+    }
+
+    // Transposed weights for output-parallel computation (groups==1 only):
+    // weights_ot[kernel_pos][in_channel][out_simd_group]
+    // Each v_type spans v_size consecutive output channels.
+    if(groups == 1 && use_output_parallel)
+    {
+        for(int j = 0; j < kernel_size; ++j)
+        {
+            for(int ic = 0; ic < in_size; ++ic)
+            {
+                for(int oc = 0; oc < out_size; ++oc)
+                {
+                    auto& wv = weights_ot[j][ic][oc / v_size];
+                    wv = set_value(wv, oc % v_size, ws[oc][ic][j]);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- add an output-parallel weight layout and kernel for ungrouped compile-time XSIMD Conv1D layers when either the input or output fits in one SIMD batch
- broadcast each input lane and accumulate output vectors, avoiding a horizontal reduction for every output channel
- retain the existing input-parallel kernel for grouped convolutions and larger channel matrices

## Motivation

The existing XSIMD kernel vectorizes across input channels. That works well for larger matrices, but the horizontal reduction needed for every output channel becomes disproportionately expensive for small and asymmetric layers.

The new dispatch is deliberately limited to shapes where the output-parallel layout performed consistently better. In particular, larger shapes such as 16-by-16 continue to use the existing path.

## Performance

On a local x86-64 build with GCC, `-O3 -march=native`, and `float`, representative small-layer microbenchmarks improved by roughly:

- 20-25% for 8 input / 8 output channels
- 30% for 16 input / 8 output channels
- 45-50% for 8 input / 1 output channel

Results vary by kernel size and host CPU; the unchanged input-parallel path remains in use outside the targeted cases.

## Validation

- formatted and checked with clang-format 14.0.6
- built the Release XSIMD configuration
- passed `rtneural_test_unit` and `rtneural_test_functional`
